### PR TITLE
Version 2.0.0 - Vault Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.0.0] - 2024-11-04
+
+### Changed
+
+- Pip installation now requires you to specify optional dependencies with either
+  `pip install fidelius[aws]` for AWS Parameter Store support, 
+  `pip install fidelius[vault]` for Hashicorp Vault support or 
+  `pip install fidelius[aws,vault]` for both. 
+
+
 ## [2.0.0-dev.1] - 2024-05-16
 
 ### Added

--- a/fidelius/__init__.py
+++ b/fidelius/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '2.0.0-dev.1'
+__version__ = '2.0.0'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/fidelius/gateway/paramstore/_paramstorerepo.py
+++ b/fidelius/gateway/paramstore/_paramstorerepo.py
@@ -5,21 +5,27 @@ __all__ = [
 from fidelius.structs import *
 from fidelius.gateway._abstract import *
 
-
-import boto3
 import os
 
 import logging
 log = logging.getLogger(__name__)
 
+try:
+    import boto3
+except ImportError:
+    log.error('You are trying to use the AwsParamStoreRepo without boto3 installed.')
+    log.error('Please amend your pip install to `fidelius[aws]` to include boto3 dependencies.')
+    raise
+
 
 class AwsParamStoreRepo(_BaseFideliusRepo):
     def __init__(self, app_props: FideliusAppProps,
-                 aws_access_key_id: str = None,
-                 aws_secret_access_key: str = None,
-                 aws_key_arn: str = None,
-                 aws_region_name: str = None,
-                 aws_endpoint_url: str = None,
+                 aws_access_key_id: Optional[str] = None,
+                 aws_secret_access_key: Optional[str] = None,
+                 aws_key_arn: Optional[str] = None,
+                 aws_region_name: Optional[str] = None,
+                 aws_endpoint_url: Optional[str] = None,
+                 aws_profile_name: Optional[str] = None,
                  flush_cache_every_time: bool = False,
                  **kwargs):
         """Fidelius Admin Repo that uses AWS' Simple Systems Manager's Parameter Store as a back end.
@@ -45,6 +51,7 @@ class AwsParamStoreRepo(_BaseFideliusRepo):
                                  testing and development, e.g. by spinning up a
                                  LocalStack container and pointing to that
                                  instead of a live AWS environment.
+        :param aws_profile_name: ....add this @TODO
         :param flush_cache_every_time: Optional flat that'll flush the entire
                                        cache before every operation if set to
                                        True and is just intended for testing

--- a/fidelius/gateway/vault/_client.py
+++ b/fidelius/gateway/vault/_client.py
@@ -3,11 +3,17 @@ __all__ = [
 ]
 from fidelius.structs import *
 from ._structs import *
-import hvac
-
 
 import logging
 log = logging.getLogger(__file__)
+
+
+try:
+    import hvac
+except ImportError:
+    log.error('You are trying to use the VaultKeyValRepo without hvac installed.')
+    log.error('Please amend your pip install to `fidelius[vaulst]` to include hvac dependencies.')
+    raise
 
 
 class VaultGateway:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,12 @@ classifiers = [
 ]
 dependencies = [
     "ccptools >=1.1, <2",
-    "boto3 >=1.20, <2",
-    "havc >= 2.2, <3"
 ]
+
+[project.optional-dependencies]
+vault = ["havc >= 2.2, <3"]
+aws = ["boto3 >=1.20, <2"]
+
 
 [project.urls]
 Homepage = "https://github.com/ccpgames/fidelius"


### PR DESCRIPTION
### Changed

- Pip installation now requires you to specify optional dependencies with either `pip install fidelius[aws]` for AWS Parameter Store support, `pip install fidelius[vault]` for Hashicorp Vault support or `pip install fidelius[aws,vault]` for both.